### PR TITLE
Add a check that the user has a sufficient version of clojure before running the koans.

### DIFF
--- a/src/path_to_enlightenment.clj
+++ b/src/path_to_enlightenment.clj
@@ -30,6 +30,14 @@
       "destructuring"
       "refs"])
 
+(defn require-version [[required-major required-minor]]
+  (let [{:keys [major minor]} *clojure-version*]
+    (if (or (< major required-major)
+        (and (== major required-major) (< minor required-minor)))
+      (throw (Exception. (str "Clojure version " required-major "."
+                              required-minor " or higher required."))))))
+
 (defn run []
+  (require-version [1 3])
   (apply load (doall (map (partial str "koans/") ordered-koans)))
   (println "You have achieved clojure enlightenment. Namaste."))


### PR DESCRIPTION
Hi,
I think it would be useful to check the clojure version that a user is running before running the koans. My patch does this with a check using *clojure-version* in the run method.
