### PR TITLE
Small change to scripts to work on cygwin

### DIFF
--- a/script/repl
+++ b/script/repl
@@ -5,4 +5,8 @@ for f in lib/*.jar; do
   CLASSPATH=$CLASSPATH:$f
 done
 
+if [ "$OSTYPE" = "cygwin" ]; then
+	CLASSPATH=`cygpath -wp $CLASSPATH`
+fi
+
 java -Xmx1G -cp $CLASSPATH jline.ConsoleRunner clojure.main

--- a/script/run
+++ b/script/run
@@ -5,5 +5,9 @@ for f in lib/*.jar; do
   CLASSPATH=$CLASSPATH:$f
 done
 
+if [ "$OSTYPE" = "cygwin" ]; then
+	CLASSPATH=`cygpath -wp $CLASSPATH`
+fi
+
 java -cp "$CLASSPATH" clojure.main -i script/run.clj
 echo

--- a/script/test
+++ b/script/test
@@ -5,5 +5,9 @@ for f in lib/*.jar; do
   CLASSPATH=$CLASSPATH:$f
 done
 
+if [ "$OSTYPE" = "cygwin" ]; then
+	CLASSPATH=`cygpath -wp $CLASSPATH`
+fi
+
 java -cp "$CLASSPATH" clojure.main -i script/test.clj
 echo


### PR DESCRIPTION
I started trying out clojure-koans on my windows work machine today and found that by doing a small tweak to the scripts/{run,test,repl} shell scripts would allow them to work in cygwin.  The windows batch files worked fine - but it just felt more natural when under cygwin to run the shell scripts.

The change is simply to check for cygwin and if existent then it updates the CLASSPATH to use Windows style PATH delimiters (';' instead of ':').

I hope this is acceptable.
