### PR TITLE
Idiomatic keywords

### DIFF
--- a/src/koans/conditionals.clj
+++ b/src/koans/conditionals.clj
@@ -28,8 +28,8 @@
 
   "You may have a multitude of possible paths"
   (let [x 5]
-    (= :your_road (cond (= x __) :road_not_taken
-                        (= x __) :another_road_not_taken
+    (= :your-road (cond (= x __) :road-not-taken
+                        (= x __) :another-road-not-taken
                         :else __)))
 
   "Or your fate may be sealed"

--- a/src/path_to_answer_sheet.clj
+++ b/src/path_to_answer_sheet.clj
@@ -72,7 +72,7 @@
                          []
                          nil
                          :glory
-                         4 6 :your_road
+                         4 6 :your-road
                          ''doom 0
                          :cocked-pistol
                          :say-what?]}


### PR DESCRIPTION
It just feels wrong using underscore to separate words when a dash is perfectly acceptable. :)
