### PR TITLE
Added entry into project.clj to allow 'lein run run' to simply work

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,5 +2,5 @@
   :description "The functional koans."
   :dependencies [[org.clojure/clojure "1.3.0"]
                  [koan-engine "0.1.2-SNAPSHOT"]]
-  :dev-dependencies [[swank-clojure "1.3.0" :exclusions [org.clojure/clojure]]
-                     [lein-koan "0.1.0"]])
+  :dev-dependencies [[swank-clojure "1.3.0" :exclusions [org.clojure/clojure]] [lein-koan "0.1.0"]]
+  :main koan-engine.runner/exec)


### PR DESCRIPTION
Rather than replying on the scripts, adding this entry into your project.clj under the :main keyword means that 'lein run run' works as expected.
