### PR TITLE
Update src/koans/13_recursion.clj

### DIFF
--- a/src/koans/13_recursion.clj
+++ b/src/koans/13_recursion.clj
@@ -16,6 +16,9 @@
 (defn factorial [n]
   __)
 
+(defn factorial-bigint [n]
+  __)
+
 (meditations
   "Recursion ends with a base case"
   (= true (is-even? 0))
@@ -45,7 +48,7 @@
   (= 24 (factorial 4))
 
   "You can even deal with very large numbers"
-  (< 1000000000000000000000000N (factorial 1000N))
+  (< 1000000000000000000000000N (factorial-bigint 1000N))
 
   "But what happens when the machine limits you?"
-  (< 1000000000000000000000000N (factorial 100003N)))
+  (< 1000000000000000000000000N (factorial-bigint 100003N)))


### PR DESCRIPTION
Made a separate function for the factorial function applied to bigints.

The reason for this is that the user gets a java.lang.StackOverflowError exception after successfully implementing a solution for a koan.

The koan in question is titled "Simple things may appear simple.", though there are a few more koans after (but they can be solved in the same step as this one).
