### PR TITLE
Ignore Leiningen plugins folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target
 *.jar
 .DS_Store
 .lein-deps-sum
+.lein-plugins


### PR DESCRIPTION
On first time install with `lein deps`, it created lein-plugins folder so, ignoring it.
