### PR TITLE
Correct 'is' to 'are' in koan description. 

### DIFF
--- a/src/koans/10_lazy_sequences.clj
+++ b/src/koans/10_lazy_sequences.clj
@@ -1,5 +1,5 @@
 (meditations
-  "There is a wide range of ways to generate a sequence"
+  "There are a wide range of ways to generate a sequence"
   (= __ (range 1 5))
 
   "The range starts at the beginning by default"


### PR DESCRIPTION
I don't mean to be That Guy, but it's more correct to use 'are', rather than 'is' when discussing a plural subject. 
