### PR TITLE
Updates to Clojure 1.5.0 final

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ exercises you've already completed.
 The only things you'll need to run the Clojure Koans are:
 
 - JRE 1.5 or higher
-- [clojure-1.3.0.jar](http://repo1.maven.org/maven2/org/clojure/clojure/1.3.0/clojure-1.3.0.zip)
+- [clojure-1.5.0.jar](http://repo1.maven.org/maven2/org/clojure/clojure/1.5.0/clojure-1.5.0.zip)
 
 You can use [Leiningen](http://github.com/technomancy/leiningen) to
 automatically install the Clojure jar in the right place. Leiningen will also

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject clojure-koans "0.4.7"
+(defproject clojure-koans "0.4.8"
   :description "The Clojure koans."
-  :dependencies [[org.clojure/clojure "1.3.0"]
+  :dependencies [[org.clojure/clojure "1.5.0"]
                  [koan-engine "0.1.3"]]
   :dev-dependencies [[lein-koan "0.1.2"]]
   :profiles {:dev {:dependencies [[lein-koan "0.1.2"]]}}


### PR DESCRIPTION
`lein koan test` passes. I'm not sure if there are other tests to worry about before upgrading to Clojure 1.5.

```
[skim@master][~/lolcat/clj/clojure-koans] lein koan test
Retrieving org/clojure/clojure/1.5.0/clojure-1.5.0.pom from central
Retrieving koan-engine/koan-engine/0.1.3/koan-engine-0.1.3.pom from clojars
Retrieving org/clojure/clojure/1.5.0/clojure-1.5.0.jar from central
Retrieving koan-engine/koan-engine/0.1.3/koan-engine-0.1.3.jar from clojars

Tests all fail before the answers are filled in.

All tests pass after the answers are filled in.
```
