### PR TITLE
Added missing word in code comments

### DIFF
--- a/src/koans/11_sequence_comprehensions.clj
+++ b/src/koans/11_sequence_comprehensions.clj
@@ -17,7 +17,7 @@
      (for [index __ :when (odd? index)]
        index))
 
-  "Combinations these transformations is trivial"
+  "Combinations of these transformations is trivial"
   (= '(1 9 25 49 81)
      (map (fn [index] (* index index))
           (filter odd? (range 10)))


### PR DESCRIPTION
Just a minor fix. Added the missing word "of" in one of the code comments for koan 11.
