### PR TITLE
Fix grammer.

### DIFF
--- a/src/koans/13_recursion.clj
+++ b/src/koans/13_recursion.clj
@@ -29,7 +29,7 @@
   "Reversing directions is easy when you have not gone far"
   (= '(1) (recursive-reverse [1]))
 
-  "Yet more difficult the more steps you take"
+  "Yet the more difficult the more steps you take"
   (= '(5 4 3 2 1) (recursive-reverse [1 2 3 4 5]))
 
   "Simple things may appear simple."


### PR DESCRIPTION
This pull request commits a simple grammar fix.
The first "the" was missing in the following koan:

"Yet the more difficult the more steps you take"
