### PR TITLE
rearranging map keys to prove sort function

### DIFF
--- a/src/koans/05_maps.clj
+++ b/src/koans/05_maps.clj
@@ -40,7 +40,7 @@
 
   "Often you will need to get the keys, but the order is undependable"
   (= (list __ __ __)
-     (sort (keys {2006 "Torino" 2010 "Vancouver" 2014 "Sochi"})))
+     (sort (keys {2010 "Vancouver" 2014 "Sochi" 2006 "Torino"})))
 
   "You can get the values in a similar way"
   (= (list "Sochi" "Torino" __)


### PR DESCRIPTION
In this example the keys were already sorted.  It seemed to make more sense to me to have the keys unsorted since we are testing the sort function.  I kept the values associated with the same original keys but rearranged the key/value pairs.
