### PR TITLE
Adding a 'contains?' example to the vector topic

### DIFF
--- a/src/koans/03_vectors.clj
+++ b/src/koans/03_vectors.clj
@@ -26,5 +26,8 @@
   "You can also slice a vector"
   (= __ (subvec [:peanut :butter :and :jelly] 1 3))
 
+  "You can find out if a value is in a vector"
+  (= __ (contains? [1 2 3] 4))
+
   "Equality with collections is in terms of values"
   (= (list 1 2 3) (vector 1 2 __)))


### PR DESCRIPTION
I noticed there are `contains?` examples for map already. Hopefully this is useful.
