### PR TITLE
Making the if-not example a bit clearer

### DIFF
--- a/resources/koans.clj
+++ b/resources/koans.clj
@@ -73,7 +73,7 @@
                         nil
                         :glory
                         4 6 :your-road
-                        'doom 0
+                        1
                         :cocked-pistol
                         :say-what?]}]
 
@@ -208,5 +208,5 @@
                         '((0 1 2) (3 4))
                         5
                         :hello
-                        (6 :this :are)
+                        (6 :these :are)
                         ]}]]

--- a/src/koans/07_conditionals.clj
+++ b/src/koans/07_conditionals.clj
@@ -33,9 +33,9 @@
                         :else __)))
 
   "Or your fate may be sealed"
-  (= __ (if-not (zero? __)
+  (= 'doom (if-not (zero? __)
           'doom
-          'doom))
+          'more-doom))
 
   "In case of emergency, sound the alarms"
   (= :sirens


### PR DESCRIPTION
I felt the example wasn't very clear as the conditional returned the quoted form of `doom` when it evaluated to true or false. This way the user needs to find a value that satisfies the if-not conditional so it returns `doom` and not `more-doom`.
