### PR TITLE
The answer file's expression returns the argument provided

### DIFF
--- a/resources/koans.clj
+++ b/resources/koans.clj
@@ -101,7 +101,7 @@
                           95
                           (range 20)
                           :a]
-                    "___" [(fn [x] :foo)]}]
+                    "___" [(fn [x] x)]}]
 
  ["11_sequence_comprehensions" {"__" [[0 1 2 3 4 5]
                                    (* index index)


### PR DESCRIPTION
Although the answer file's entry worked, it ignored the provided argument. With this change it returns what was passed to it.
I branched from master, I hope it can be merged it in.
