### PR TITLE
Switch variable from index to x to avoid confusing syntax highlightig.

### DIFF
--- a/src/koans/11_sequence_comprehensions.clj
+++ b/src/koans/11_sequence_comprehensions.clj
@@ -1,27 +1,27 @@
 (meditations
   "Sequence comprehensions can bind each element in turn to a symbol"
   (= __
-     (for [index (range 6)]
-       index))
+     (for [x (range 6)]
+       x))
 
   "They can easily emulate mapping"
   (= '(0 1 4 9 16 25)
-     (map (fn [index] (* index index))
+     (map (fn [x] (* x x))
           (range 6))
-     (for [index (range 6)]
+     (for [x (range 6)]
        __))
 
   "And also filtering"
   (= '(1 3 5 7 9)
      (filter odd? (range 10))
-     (for [index __ :when (odd? index)]
-       index))
+     (for [x __ :when (odd? x)]
+       x))
 
   "Combinations of these transformations is trivial"
   (= '(1 9 25 49 81)
-     (map (fn [index] (* index index))
+     (map (fn [x] (* x x))
           (filter odd? (range 10)))
-     (for [index (range 10) :when __]
+     (for [x (range 10) :when __]
        __))
 
   "More complex transformations simply take multiple binding forms"


### PR DESCRIPTION
index is a clojure.set function and ended up highlighted for me, sending me
down a rabbit hole of confusion. Avoid this with a more generic variable name
consistent with other Koan files.
