### PR TITLE
Add Counterclockwise integration

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+  <classpathentry kind="src" path="src"/>
+  <classpathentry kind="lib" path="/Users/gary/ena/talk/2014-01-18-clojure-full-day/workspace/clojure-koans/target/classes"/>
+  <classpathentry kind="lib" path="/Users/gary/.m2/repository/jline/jline/0.9.94/jline-0.9.94.jar"/>
+  <classpathentry kind="lib" path="/Users/gary/.m2/repository/clj-time/clj-time/0.5.0/clj-time-0.5.0.jar"/>
+  <classpathentry kind="lib" path="/Users/gary/.m2/repository/fresh/fresh/1.0.2/fresh-1.0.2.jar"/>
+  <classpathentry kind="lib" path="/Users/gary/.m2/repository/koan-engine/koan-engine/0.2.0/koan-engine-0.2.0.jar"/>
+  <classpathentry kind="lib" path="/Users/gary/.m2/repository/org/clojure/tools.nrepl/0.2.3/tools.nrepl-0.2.3.jar"/>
+  <classpathentry kind="lib" path="/Users/gary/.m2/repository/spyscope/spyscope/0.1.4/spyscope-0.1.4.jar"/>
+  <classpathentry kind="lib" path="/Users/gary/.m2/repository/org/clojure/clojure/1.5.1/clojure-1.5.1.jar"/>
+  <classpathentry kind="lib" path="/Users/gary/.m2/repository/clojure-complete/clojure-complete/0.2.3/clojure-complete-0.2.3.jar"/>
+  <classpathentry kind="lib" path="/Users/gary/.m2/repository/lein-koan/lein-koan/0.1.2/lein-koan-0.1.2.jar"/>
+  <classpathentry kind="lib" path="/Users/gary/.m2/repository/joda-time/joda-time/2.2/joda-time-2.2.jar"/>
+  <classpathentry kind="src" path="resources"/>
+  <classpathentry path="org.eclipse.jdt.launching.JRE_CONTAINER" kind="con"/>
+  <classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/.project
+++ b/.project
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+  <name>clojure-koans</name>
+  <comment>The Clojure koans.</comment>
+  <projects/>
+  <buildSpec>
+    <buildCommand>
+      <name>ccw.builder</name>
+      <arguments/>
+    </buildCommand>
+    <buildCommand>
+      <name>org.eclipse.jdt.core.javabuilder</name>
+      <arguments/>
+    </buildCommand>
+  </buildSpec>
+  <natures>
+    <nature>ccw.nature</nature>
+    <nature>org.eclipse.jdt.core.javanature</nature>
+  </natures>
+</projectDescription>

--- a/project.clj
+++ b/project.clj
@@ -5,5 +5,6 @@
   :dev-dependencies [[lein-koan "0.1.2"]]
   :profiles {:dev {:dependencies [[lein-koan "0.1.2"]]}}
   :repl-options {:init-ns user}
-  :plugins [[lein-koan "0.1.2"]]
+  :plugins [[lein-koan "0.1.2"]
+            [lein2-eclipse "2.0.0"]]
   :main koan-engine.runner/exec)

--- a/src/koans/01_equalities.clj
+++ b/src/koans/01_equalities.clj
@@ -1,3 +1,6 @@
+(ns koans.01-equalities
+  (:require (koan-engine [core :refer [meditations __]])))
+
 (meditations
   "We shall contemplate truth by testing reality, via equality"
   (= __ true)

--- a/src/koans/02_lists.clj
+++ b/src/koans/02_lists.clj
@@ -1,3 +1,6 @@
+(ns koans.02-lists
+  (:require (koan-engine [core :refer [meditations __]])))
+
 (meditations
   "Lists can be expressed by function or a quoted form"
   (= '(__ __ __ __ __) (list 1 2 3 4 5))

--- a/src/koans/03_vectors.clj
+++ b/src/koans/03_vectors.clj
@@ -1,3 +1,6 @@
+(ns koans.03-vectors
+  (:require (koan-engine [core :refer [meditations __]])))
+
 (meditations
   "You can use vectors in clojure as array-like structures"
   (= __ (count [42]))

--- a/src/koans/04_sets.clj
+++ b/src/koans/04_sets.clj
@@ -1,3 +1,6 @@
+(ns koans.04-sets
+  (:require (koan-engine [core :refer [meditations __]])))
+
 (meditations
   "You can create a set by converting another collection"
   (= #{3} (set __))

--- a/src/koans/05_maps.clj
+++ b/src/koans/05_maps.clj
@@ -1,3 +1,6 @@
+(ns koans.05-maps
+  (:require (koan-engine [core :refer [meditations __]])))
+
 (meditations
   "Don't get lost when creating a map"
   (= {:a 1 :b 2} (hash-map :a 1 __ __))

--- a/src/koans/06_functions.clj
+++ b/src/koans/06_functions.clj
@@ -1,3 +1,6 @@
+(ns koans.06-functions
+  (:require (koan-engine [core :refer [meditations __ ___]])))
+
 (defn multiply-by-ten [n]
   (* 10 n))
 

--- a/src/koans/07_conditionals.clj
+++ b/src/koans/07_conditionals.clj
@@ -1,3 +1,6 @@
+(ns koans.07-conditionals
+  (:require (koan-engine [core :refer [meditations __]])))
+
 (defn explain-defcon-level [exercise-term]
   (case exercise-term
         :fade-out          :you-and-what-army

--- a/src/koans/08_higher_order_functions.clj
+++ b/src/koans/08_higher_order_functions.clj
@@ -1,3 +1,6 @@
+(ns koans.08-higher-order-functions
+  (:require (koan-engine [core :refer [meditations __]])))
+
 (meditations
   "The map function relates a sequence to another"
   (= [__ __ __] (map (fn [x] (* 4 x)) [1 2 3]))

--- a/src/koans/09_runtime_polymorphism.clj
+++ b/src/koans/09_runtime_polymorphism.clj
@@ -1,3 +1,6 @@
+(ns koans.09-runtime-polymorphism
+  (:require (koan-engine [core :refer [meditations __]])))
+
 (defn hello
   ([] "Hello World!")
   ([a] (str "Hello, you silly " a "."))

--- a/src/koans/10_lazy_sequences.clj
+++ b/src/koans/10_lazy_sequences.clj
@@ -1,3 +1,6 @@
+(ns koans.10-lazy-sequences
+  (:require (koan-engine [core :refer [meditations __]])))
+
 (meditations
   "There are many ways to generate a sequence"
   (= __ (range 1 5))

--- a/src/koans/11_sequence_comprehensions.clj
+++ b/src/koans/11_sequence_comprehensions.clj
@@ -1,3 +1,6 @@
+(ns koans.11-sequence-comprehensions
+  (:require (koan-engine [core :refer [meditations __]])))
+
 (meditations
   "Sequence comprehensions can bind each element in turn to a symbol"
   (= __

--- a/src/koans/12_creating_functions.clj
+++ b/src/koans/12_creating_functions.clj
@@ -1,3 +1,6 @@
+(ns koans.12-creating-functions
+  (:require (koan-engine [core :refer [meditations __ ___]])))
+
 (defn square [x] (* x x))
 
 (meditations

--- a/src/koans/13_recursion.clj
+++ b/src/koans/13_recursion.clj
@@ -1,3 +1,6 @@
+(ns koans.13-recursion
+  (:require (koan-engine [core :refer [meditations __ ___]])))
+
 (defn is-even? [n]
   (if (= n 0)
     __

--- a/src/koans/14_destructuring.clj
+++ b/src/koans/14_destructuring.clj
@@ -1,3 +1,6 @@
+(ns koans.14-destructuring
+  (:require (koan-engine [core :refer [meditations __ ___]])))
+
 (def test-address
   {:street-address "123 Test Lane"
    :city "Testerville"

--- a/src/koans/15_refs.clj
+++ b/src/koans/15_refs.clj
@@ -1,3 +1,6 @@
+(ns koans.15-refs
+  (:require (koan-engine [core :refer [meditations __ ___]])))
+
 (def the-world (ref "hello"))
 (def bizarro-world (ref {}))
 

--- a/src/koans/16_atoms.clj
+++ b/src/koans/16_atoms.clj
@@ -1,3 +1,6 @@
+(ns koans.16-atoms
+  (:require (koan-engine [core :refer [meditations __]])))
+
 (def atomic-clock (atom 0))
 
 (meditations

--- a/src/koans/17_macros.clj
+++ b/src/koans/17_macros.clj
@@ -1,3 +1,6 @@
+(ns koans.17-macros
+  (:require (koan-engine [core :refer [meditations __]])))
+
 (defmacro hello [x]
   (str "Hello, " x))
 

--- a/src/koans/18_datatypes.clj
+++ b/src/koans/18_datatypes.clj
@@ -1,3 +1,6 @@
+(ns koans.18-datatypes
+  (:require (koan-engine [core :refer [meditations __]])))
+
 (defrecord Nobel [prize])
 (deftype Pulitzer [prize])
 

--- a/src/koans/19_java_interop.clj
+++ b/src/koans/19_java_interop.clj
@@ -1,3 +1,6 @@
+(ns koans.19-java-interop
+  (:require (koan-engine [core :refer [meditations __ ___]])))
+
 (meditations
   "You may have done more with Java than you know"
   (= __ (class "warfare")) ; hint: try typing (javadoc "warfare") in the REPL

--- a/src/koans/20_partition.clj
+++ b/src/koans/20_partition.clj
@@ -1,3 +1,6 @@
+(ns koans.20-partition
+  (:require (koan-engine [core :refer [meditations __]])))
+
 (meditations
   "To split a collection you can use the partition function"
   (= '((0 1) (2 3)) (__ 2 (range 4)))

--- a/src/koans/21_group_by.clj
+++ b/src/koans/21_group_by.clj
@@ -1,3 +1,6 @@
+(ns koans.21-group-by
+  (:require (koan-engine [core :refer [meditations __]])))
+
 (defn get-odds-and-evens [coll]
   (let [{odds true evens false} (group-by __ coll)]
     [odds evens]))


### PR DESCRIPTION
At the cost of adding a little noise at the start of each file, this change makes it possible to enable docstrings and autocompletion in Eclipse (and, I suppose, other editors).

In my experience trying to get people to learn Clojure, Counterclockwise has been a great asset since Eclipse is already well-known in the Java world and CCW now has [a ready-to-use bundle for each major platform](http://standalone.ccw-ide.org).

With this patch, the clojure-koans project can be easily cloned and imported from the standalone CCW (which includes the git plugin); having a namespace declaration in each file allows the user to use the interactive features of CCW (a beginner probably only needs CTRL+ALT+S for evaluating the whole file) and to get access to the docstrings as tooltips.

As a reference, here are the instruction notes I have written for people wanting to learn Clojure inside my company:
## 

The easiest way to get started with the Clojure syntax is probably the [online Clojure koans](http://clojurescriptkoans.com). For better syntax highlighting, formatting, and docs, install the koans locally with the following steps:
1. Download the [Counterclockwise bundle](http://standalone.ccw-ide.org) for your platform.
2. Create a folder and unzip the bundle inside it.
3. Open the Counterclockwise executable.
4. Import [my fork of the Clojure Koans](https://github.com/gaverhae/clojure-koans) project into Eclipse. The git plugin is included in Counterclockwise. (Click Window -> Open Perspective -> Other... -> Git Repository Exploring -> Clone a git repository -> git@github.com:gaverhae/clojure-koans.git -> Next -> Next -> Choose path and click Finish -> Right click on the repository -> Import Projects... -> Next -> Finish.)
5. In the Java perspective, right click on the project and choose Leiningen -> Generic Leiningen Command Line and replace "<task>" with "koan run". This sets up a program that will check the koans every time you save a file, and tell you which is the first koan that is not complete yet.
6. Still in the Java perspective, open the first koan (01_equalities.clj) and press CTRL+ALT+S to evaluate the file in a newly created REPL. This will enable documentation tooltips and autocompletion features.

Within Counterclockwise, CTRL+ALT+S evaluates the active file and CTRL+ENTER evaluates the top-level form under the cursor. Try it out, it'll be clearer than trying to explain that here.
## 

It's a bit more than "unzip and run", but they also end up with a complete development environment ready to go. Note that this patch also solves issue #68 and probably any other editor, as it makes the project sort of "standards compliant".
