### PR TITLE
Add name-spaces to the clojure koans files.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,9 @@
                  [koan-engine "0.2.0"]]
   :dev-dependencies [[lein-koan "0.1.2"]]
   :profiles {:dev {:dependencies [[lein-koan "0.1.2"]]}}
-  :repl-options {:init-ns user}
+  :repl-options {
+                 :init-ns koan-engine.runner
+                 :init (use 'koan-engine.core)
+                 }
   :plugins [[lein-koan "0.1.2"]]
   :main koan-engine.runner/exec)

--- a/src/koans/01_equalities.clj
+++ b/src/koans/01_equalities.clj
@@ -1,3 +1,6 @@
+(ns koan-engine.runner)
+(ns koans.01-equalities (:use koan-engine.core))
+
 (meditations
   "We shall contemplate truth by testing reality, via equality"
   (= __ true)

--- a/src/koans/02_lists.clj
+++ b/src/koans/02_lists.clj
@@ -1,3 +1,6 @@
+(ns koan-engine.runner)
+(ns koans.02-lists (:use koan-engine.core))
+
 (meditations
   "Lists can be expressed by function or a quoted form"
   (= '(__ __ __ __ __) (list 1 2 3 4 5))

--- a/src/koans/03_vectors.clj
+++ b/src/koans/03_vectors.clj
@@ -1,3 +1,6 @@
+(ns koan-engine.runner)
+(ns koans.03-vectors (:use koan-engine.core))
+
 (meditations
   "You can use vectors in clojure as array-like structures"
   (= __ (count [42]))

--- a/src/koans/04_sets.clj
+++ b/src/koans/04_sets.clj
@@ -1,3 +1,6 @@
+(ns koan-engine.runner)
+(ns koans.04-sets (:use koan-engine.core))
+
 (meditations
   "You can create a set by converting another collection"
   (= #{3} (set __))

--- a/src/koans/05_maps.clj
+++ b/src/koans/05_maps.clj
@@ -1,3 +1,6 @@
+(ns koan-engine.runner)
+(ns koans.05-maps (:use koan-engine.core))
+
 (meditations
   "Don't get lost when creating a map"
   (= {:a 1 :b 2} (hash-map :a 1 __ __))

--- a/src/koans/06_functions.clj
+++ b/src/koans/06_functions.clj
@@ -1,3 +1,6 @@
+(ns koan-engine.runner)
+(ns koans.06-functions (:use koan-engine.core))
+
 (defn multiply-by-ten [n]
   (* 10 n))
 

--- a/src/koans/07_conditionals.clj
+++ b/src/koans/07_conditionals.clj
@@ -1,3 +1,6 @@
+(ns koan-engine.runner)
+(ns koans.07-conditionals (:use koan-engine.core))
+
 (defn explain-defcon-level [exercise-term]
   (case exercise-term
         :fade-out          :you-and-what-army

--- a/src/koans/08_higher_order_functions.clj
+++ b/src/koans/08_higher_order_functions.clj
@@ -1,3 +1,6 @@
+(ns koan-engine.runner)
+(ns koans.08-higher-order-functions (:use koan-engine.core))
+
 (meditations
   "The map function relates a sequence to another"
   (= [__ __ __] (map (fn [x] (* 4 x)) [1 2 3]))

--- a/src/koans/09_runtime_polymorphism.clj
+++ b/src/koans/09_runtime_polymorphism.clj
@@ -1,3 +1,6 @@
+(ns koan-engine.runner)
+(ns koans.09-runtime-polymorphism (:use koan-engine.core))
+
 (defn hello
   ([] "Hello World!")
   ([a] (str "Hello, you silly " a "."))

--- a/src/koans/10_lazy_sequences.clj
+++ b/src/koans/10_lazy_sequences.clj
@@ -1,3 +1,6 @@
+(ns koan-engine.runner)
+(ns koans.10-lazy-sequences (:use koan-engine.core))
+
 (meditations
   "There are many ways to generate a sequence"
   (= __ (range 1 5))

--- a/src/koans/11_sequence_comprehensions.clj
+++ b/src/koans/11_sequence_comprehensions.clj
@@ -1,3 +1,6 @@
+(ns koan-engine.runner)
+(ns koans.11-sequence-comprehensions (:use koan-engine.core))
+
 (meditations
   "Sequence comprehensions can bind each element in turn to a symbol"
   (= __

--- a/src/koans/12_creating_functions.clj
+++ b/src/koans/12_creating_functions.clj
@@ -1,3 +1,6 @@
+(ns koan-engine.runner)
+(ns koans.12-creating-functions (:use koan-engine.core))
+
 (defn square [x] (* x x))
 
 (meditations

--- a/src/koans/13_recursion.clj
+++ b/src/koans/13_recursion.clj
@@ -1,3 +1,6 @@
+(ns koan-engine.runner)
+(ns koans.13-recursion (:use koan-engine.core))
+
 (defn is-even? [n]
   (if (= n 0)
     __

--- a/src/koans/14_destructuring.clj
+++ b/src/koans/14_destructuring.clj
@@ -1,3 +1,6 @@
+(ns koan-engine.runner)
+(ns koans.14-destructuring (:use koan-engine.core))
+
 (def test-address
   {:street-address "123 Test Lane"
    :city "Testerville"

--- a/src/koans/15_refs.clj
+++ b/src/koans/15_refs.clj
@@ -1,3 +1,6 @@
+(ns koan-engine.runner)
+(ns koans.15-refs (:use koan-engine.core))
+
 (def the-world (ref "hello"))
 (def bizarro-world (ref {}))
 

--- a/src/koans/16_atoms.clj
+++ b/src/koans/16_atoms.clj
@@ -1,3 +1,6 @@
+(ns koan-engine.runner)
+(ns koans.16-atoms (:use koan-engine.core))
+
 (def atomic-clock (atom 0))
 
 (meditations

--- a/src/koans/17_macros.clj
+++ b/src/koans/17_macros.clj
@@ -1,3 +1,6 @@
+(ns koan-engine.runner)
+(ns koans.17-macros (:use koan-engine.core))
+
 (defmacro hello [x]
   (str "Hello, " x))
 

--- a/src/koans/18_datatypes.clj
+++ b/src/koans/18_datatypes.clj
@@ -1,3 +1,6 @@
+(ns koan-engine.runner)
+(ns koans.18-datatypes (:use koan-engine.core))
+
 (defrecord Nobel [prize])
 (deftype Pulitzer [prize])
 

--- a/src/koans/19_java_interop.clj
+++ b/src/koans/19_java_interop.clj
@@ -1,3 +1,6 @@
+(ns koan-engine.runner)
+(ns koans.19-java-interop (:use koan-engine.core))
+
 (meditations
   "You may have done more with Java than you know"
   (= __ (class "warfare")) ; hint: try typing (javadoc "warfare") in the REPL

--- a/src/koans/20_partition.clj
+++ b/src/koans/20_partition.clj
@@ -1,3 +1,6 @@
+(ns koan-engine.runner)
+(ns koans.20-partition (:use koan-engine.core))
+
 (meditations
   "To split a collection you can use the partition function"
   (= '((0 1) (2 3)) (__ 2 (range 4)))

--- a/src/koans/21_group_by.clj
+++ b/src/koans/21_group_by.clj
@@ -1,3 +1,6 @@
+(ns koan-engine.runner)
+(ns koans.21-group-by (:use koan-engine.core))
+
 (defn get-odds-and-evens [coll]
   (let [{odds true evens false} (group-by __ coll)]
     [odds evens]))


### PR DESCRIPTION
This pull request is essentially a duplicate of #69 but without the eclipse specific entries.

I also added the `(ns koan-engine.runner)` expression to the beginning of each file (the order matters).  
This change fixes the issue in #68 (although I'm not certain how).

In order for this to work without causing failure of koan test then functional-koans/clojure-koan-engine#9
needs to be merged into the koan-engine project.
