### PR TITLE
Invoke the koan-engine ns initializer.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,9 @@
                  [koan-engine "0.2.0"]]
   :dev-dependencies [[lein-koan "0.1.2"]]
   :profiles {:dev {:dependencies [[lein-koan "0.1.2"]]}}
-  :repl-options {:init-ns user}
+  :repl-options {
+                 :init-ns koan-engine.repl
+                 :init (do-ns-koans)
+                 }
   :plugins [[lein-koan "0.1.2"]]
   :main koan-engine.runner/exec)


### PR DESCRIPTION
The idea behind this is to clean-up the repl initialization as proposed
in pull request #68 such that it's taken care of in a back compatible
way from the koans-engine project.

This pull request is the alternative to #71.  It's implementation will require
functional-koans/clojure-koan-engine#10 to be merged

More details of the pros and cons of this approach are provided in that pull
request as the majority of the work is handled by the koan-eninge project.
