### PR TITLE
fix an error on the answer sheet

### DIFF
--- a/resources/koans.clj
+++ b/resources/koans.clj
@@ -54,7 +54,7 @@
                 false
                 "February"
                 1 "January"
-                2006 2010 2014
+                2010 2014 2018
                 "PyeongChang" "Sochi" "Vancouver"]}]
 
  ["06_functions" {"__" [81


### PR DESCRIPTION
There might be a tiny error on the answer sheet(/resources/koans.clj) for passing ```lein koan test```. 