### PR TITLE
First encounter with `nil`

### DIFF
--- a/src/koans/01_equalities.clj
+++ b/src/koans/01_equalities.clj
@@ -32,7 +32,7 @@
   "Symbolism is all around us"
   (= 'hello (symbol __))
 
-  "Introducing nil"
+  "What could be equivalent to nothing?"
   (= __ nil)
 
   "When things cannot be equal, they must be different"

--- a/src/koans/01_equalities.clj
+++ b/src/koans/01_equalities.clj
@@ -32,5 +32,8 @@
   "Symbolism is all around us"
   (= 'hello (symbol __))
 
+  "Introducing nil"
+  (= __ nil)
+
   "When things cannot be equal, they must be different"
   (not= :fill-in-the-blank __))


### PR DESCRIPTION
In 02_strings.clj, the answer to

   (= __ (string/index-of "hello world" "bob"))

is `nil` but `nil` is not obvious for somebody who
never saw it before. This step introduces it.