### PR TITLE
Address #117 -- add last koan in 06-maps to meditations

### DIFF
--- a/src/koans/06_maps.clj
+++ b/src/koans/06_maps.clj
@@ -53,11 +53,11 @@
 
   "You can get the values in a similar way"
   (= (list __ __ __)
-     (sort (vals {2010 "Vancouver" 2014 "Sochi" 2018 "PyeongChang"}))))
+     (sort (vals {2010 "Vancouver" 2014 "Sochi" 2018 "PyeongChang"})))
 
   "You can even iterate over the map entries as a seq"
   (= {:a __ :b __}
      (into {}
            (map
             (fn [[k v]] [k (inc v)])
-            {:a 1 :b 2})))
+            {:a 1 :b 2}))))


### PR DESCRIPTION
The closing paren for meditations occurred after the second-to-last
koan instead of the last one, so the test on the last one would never
be executed.