### PR TITLE
Add instructions for installing JDK and Leiningen via SDKMAN.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,27 @@ lein repl
 to make sure all the dependencies get downloaded properly (and then `(exit)`
 when you want to quit). See below for details on the REPL.
 
+### Installation with SDKMAN!
+
+Ensure that you have [SDKMAN! installed](https://sdkman.io/install) on your machine.
+
+Next run the following command to install the JDK if you don't have it installed:
+
+```
+sdk install java 8.0.201-zulu
+```
+
+Then install the latest version of Leiningen:
+
+```
+sdk install leiningen
+```
+
+As before, once you've cloned this repo and installed the SDKs you can run:
+
+```
+lein repl
+```
 
 ### Installation with Vagrant
 


### PR DESCRIPTION
A very easy way to get going is by using SDKMAN. It is un-invasive to your system and only installs what is needed in your home directory under a `~/.sdkman` folder. It takes seconds to install all the dependencies you will need to get up and running.