### PR TITLE
Replace all triple underscores '___' with double '__'.

### DIFF
--- a/src/koans/07_functions.clj
+++ b/src/koans/07_functions.clj
@@ -26,15 +26,15 @@
   (= __ (#(str "AA" %2) "bb" "CC"))
 
   "One function can beget another"
-  (= 9 (((fn [] ___)) 4 5))
+  (= 9 (((fn [] __)) 4 5))
 
   "Functions can also take other functions as input"
   (= 20 ((fn [f] (f 4 5))
-           ___))
+           __))
 
   "Higher-order functions take function arguments"
-  (= 25 (___
+  (= 25 (__
           (fn [n] (* n n))))
 
   "But they are often better written using the names of functions"
-  (= 25 (___ square)))
+  (= 25 (__ square)))

--- a/src/koans/11_lazy_sequences.clj
+++ b/src/koans/11_lazy_sequences.clj
@@ -25,4 +25,4 @@
 
   "Iteration can be used for repetition"
   (= (repeat 100 "hello")
-     (take 100 (iterate ___ "hello"))))
+     (take 100 (iterate __ "hello"))))

--- a/src/koans/13_creating_functions.clj
+++ b/src/koans/13_creating_functions.clj
@@ -10,12 +10,12 @@
 
   "Praise and 'complement' may help you separate the wheat from the chaff"
   (= [:wheat "wheat" 'wheat]
-       (let [not-nil? ___]
+       (let [not-nil? __]
          (filter not-nil? [nil :wheat nil "wheat" nil 'wheat nil])))
 
   "Partial functions allow procrastination"
   (= 20 (let [multiply-by-5 (partial * 5)]
-          (___ __)))
+          (__ __)))
 
   "Don't forget: first things first"
   (= [__ __ __ __]
@@ -31,5 +31,5 @@
           (double-dec 10)))
 
   "Be careful about the order in which you mix your functions"
-  (= 99 (let [square-and-dec ___]
+  (= 99 (let [square-and-dec __]
           (square-and-dec 10))))

--- a/src/koans/14_recursion.clj
+++ b/src/koans/14_recursion.clj
@@ -4,7 +4,7 @@
 (defn is-even? [n]
   (if (= n 0)
     __
-    (___ (is-even? (dec n)))))
+    (__ (is-even? (dec n)))))
 
 (defn is-even-bigint? [n]
   (loop [n   n

--- a/src/koans/15_destructuring.clj
+++ b/src/koans/15_destructuring.clj
@@ -41,4 +41,4 @@
 
   "All together now!"
   (= "Test Testerson, 123 Test Lane, Testerville, TX"
-     (___ ["Test" "Testerson"] test-address)))
+     (__ ["Test" "Testerson"] test-address)))

--- a/src/koans/16_refs.clj
+++ b/src/koans/16_refs.clj
@@ -30,7 +30,7 @@
 
   "Functions passed to alter may depend on the data in the ref"
   (= 20 (do
-          (dosync (alter the-world ___))))
+          (dosync (alter the-world __))))
 
   "Two worlds are better than one"
   (= ["Real Jerry" "Bizarro Jerry"]

--- a/src/koans/20_java_interop.clj
+++ b/src/koans/20_java_interop.clj
@@ -9,7 +9,7 @@
   (= __ (.toUpperCase "select * from"))
 
   "But instance method calls are very different from normal functions"
-  (= ["SELECT" "FROM" "WHERE"] (map ___ ["select" "from" "where"]))
+  (= ["SELECT" "FROM" "WHERE"] (map __ ["select" "from" "where"]))
 
   "Constructing might be harder than breaking"
   (= 10 (let [latch (java.util.concurrent.CountDownLatch. __)]


### PR DESCRIPTION
May as well be consistent and use the same double underscore everywhere. This consistency could make it easier to write code in the future which relies on it, and is just nicer I think.