### PR TITLE
Fix some typos and style non-uniformities

### DIFF
--- a/src/koans/02_strings.clj
+++ b/src/koans/02_strings.clj
@@ -39,7 +39,7 @@
   "Maybe you want to find the index of the first occurrence of a substring"
   (= 0 (string/index-of "hello world" __))
 
-  "Or maybe the last index of the same"
+  "Or maybe the last index of the same substring"
   (= __ (string/last-index-of "hello world, hello" "hello"))
 
   "But when something doesn't exist, nothing is found"

--- a/src/koans/05_sets.clj
+++ b/src/koans/05_sets.clj
@@ -12,7 +12,7 @@
   "Remember that a set is a *mathematical* set"
   (= __ (set '(1 1 2 2 3 3 4 4 5 5)))
 
-  "You can ask clojure for the union of two sets"
+  "You can ask Clojure for the union of two sets"
   (= __ (set/union #{1 2 3 4} #{2 3 5}))
 
   "And also the intersection"

--- a/src/koans/14_recursion.clj
+++ b/src/koans/14_recursion.clj
@@ -35,10 +35,10 @@
   "Yet it becomes more difficult the more steps you take"
   (= '(6 5 4 3 2) (recursive-reverse [2 3 4 5 6]))
 
-  "Simple things may appear simple."
+  "Simple things may appear simple"
   (= 1 (factorial 1))
 
-  "They may require other simple steps."
+  "They may require other simple steps"
   (= 2 (factorial 2))
 
   "Sometimes a slightly bigger step is necessary"

--- a/src/koans/15_destructuring.clj
+++ b/src/koans/15_destructuring.clj
@@ -29,7 +29,7 @@
      (let [[first-name last-name :as full-name] ["Stephen" "Hawking"]]
        __))
 
-  "Break up maps by key"
+  "Break up maps by keys"
   (= "123 Test Lane, Testerville, TX"
      (let [{street-address :street-address, city :city, state :state} test-address]
        __))

--- a/src/koans/21_partition.clj
+++ b/src/koans/21_partition.clj
@@ -14,8 +14,8 @@
   "If you need to, you can start each sequence with an offset"
   (= '((0 1 2) (5 6 7) (10 11 12)) (partition 3 __ (range 13)))
 
-  "Consider padding the last sequence with some default values..."
+  "Consider padding the last sequence with some default values"
   (= '((0 1 2) (3 4 5) (6 :hello)) (partition 3 3 [__] (range 7)))
 
-  "... but notice that they will only pad up to the given sequence length"
+  "But notice that they will only pad up to the given sequence length"
   (= '((0 1 2) (3 4 5) __) (partition 3 3 [:these :are "my" "words"] (range 7))))

--- a/src/koans/22_group_by.clj
+++ b/src/koans/22_group_by.clj
@@ -6,7 +6,7 @@
     [odds evens]))
 
 (meditations
-  "To categorize a collection by some function, use group-by."
+  "To categorize a collection by some function, use group-by"
   (= __ (group-by count ["hello" "world" "foo" "bar"]))
 
   "You can simulate filter + remove in one pass"

--- a/src/koans/24_macros.clj
+++ b/src/koans/24_macros.clj
@@ -38,7 +38,7 @@
   "You can do better than that - hand crafting FTW!"
   (= '(* 10 2) (macroexpand '(infix-concise (10 * 2))))
 
-  "Things don't always work as you would like them to... "
+  "Things don't always work as you would like them to"
   (= '(+ 10 (2 * 3)) (macroexpand '(infix-concise (10 + (2 * 3)))))
 
   "Really, you don't understand recursion until you understand recursion"


### PR DESCRIPTION
Polished tasks descriptions - fixed some typos and style non-uniformities.
Please add the ones that seem correct to you)